### PR TITLE
Fix --density-loss-mult 0 -> bad RGB reconstruction

### DIFF
--- a/nerfstudio/configs/method_configs.py
+++ b/nerfstudio/configs/method_configs.py
@@ -296,6 +296,10 @@ method_configs["thermal-nerfacto"] = TrainerConfig(
             "optimizer": AdamOptimizerConfig(lr=1e-3, eps=1e-15),
             "scheduler": ExponentialDecaySchedulerConfig(lr_final=1e-4, max_steps=5000),
         },
+        "camera_opt_thermal": {
+            "optimizer": AdamOptimizerConfig(lr=1e-3, eps=1e-15),
+            "scheduler": ExponentialDecaySchedulerConfig(lr_final=1e-4, max_steps=5000),
+        },
     },
     viewer=ViewerConfig(num_rays_per_chunk=1 << 15),
     vis="viewer",


### PR DESCRIPTION
This was due to a shared RGB/T camera optimizer, so camera pose tweaks from struggling to reconstruct thermal channel would affect optimization of RGB pose -> cause camera pose adjustment to be too large.